### PR TITLE
Make sure that "Exception.code" is an "int"

### DIFF
--- a/src/clikit/console_application.py
+++ b/src/clikit/console_application.py
@@ -144,7 +144,7 @@ class ConsoleApplication(BaseApplication):
         return status_code
 
     def exception_to_exit_code(self, e):  # type: (Exception) -> int
-        if not hasattr(e, "code"):
+        if not hasattr(e, "code") or not isinstance(e, int):
             return 1
 
         return min(max(e.code, 1), 255)


### PR DESCRIPTION
A user defined Exception might have a non-integer "code" attribute which makes "exception_to_exit_code()" to raise a TypeError. E.g. if "Exception.code" is a string we get:

    TypeError: '>' not supported between instances of 'int' and 'str'

One example of such a library is [schema](https://github.com/keleshev/schema). Here is the [source](https://github.com/keleshev/schema/blob/594bb17ca0a58a2a4a134a4729f9d674b699d971/schema.py#L40-L59).

With this commit we add a check that the "code" attribute is actually an int.