### PR TITLE
Fix parsing options beyond `--`

### DIFF
--- a/src/clikit/api/args/raw_args.py
+++ b/src/clikit/api/args/raw_args.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import List
 from typing import Optional
 
@@ -20,3 +21,10 @@ class RawArgs(object):
 
     def to_string(self, script_name=True):  # type: (bool) -> str
         raise NotImplementedError()
+
+    @property
+    def option_tokens(self):  # type: () -> List[str]
+        return list(itertools.takewhile(lambda arg: arg != "--", self.tokens))
+
+    def has_option_token(self, token):  # type: (str) -> bool
+        return token in self.option_tokens

--- a/src/clikit/config/default_application_config.py
+++ b/src/clikit/config/default_application_config.py
@@ -90,9 +90,9 @@ class DefaultApplicationConfig(ApplicationConfig):
 
         style_set = application.config.style_set
 
-        if args.has_token("--no-ansi"):
+        if args.has_option_token("--no-ansi"):
             output_formatter = error_formatter = PlainFormatter(style_set)
-        elif args.has_token("--ansi"):
+        elif args.has_option_token("--ansi"):
             output_formatter = error_formatter = AnsiFormatter(style_set, True)
         else:
             if output_stream.supports_ansi():
@@ -111,17 +111,17 @@ class DefaultApplicationConfig(ApplicationConfig):
             Output(error_stream, error_formatter),
         )
 
-        if args.has_token("-vvv") or self.is_debug():
+        if args.has_option_token("-vvv") or self.is_debug():
             io.set_verbosity(DEBUG)
-        elif args.has_token("-vv"):
+        elif args.has_option_token("-vv"):
             io.set_verbosity(VERY_VERBOSE)
-        elif args.has_token("-v"):
+        elif args.has_option_token("-v"):
             io.set_verbosity(VERBOSE)
 
-        if args.has_token("--quiet") or args.has_token("-q"):
+        if args.has_option_token("--quiet") or args.has_option_token("-q"):
             io.set_quiet(True)
 
-        if args.has_token("--no-interaction") or args.has_token("-n"):
+        if args.has_option_token("--no-interaction") or args.has_option_token("-n"):
             io.set_interactive(False)
 
         return io
@@ -144,7 +144,7 @@ class DefaultApplicationConfig(ApplicationConfig):
         args = event.raw_args
         application = event.application
 
-        if args.has_option_token("-h") or args.has_option_token("--help"):            
+        if args.has_option_token("-h") or args.has_option_token("--help"):
             command = application.get_command("help")
 
             # Enable lenient parsing

--- a/src/clikit/config/default_application_config.py
+++ b/src/clikit/config/default_application_config.py
@@ -144,7 +144,7 @@ class DefaultApplicationConfig(ApplicationConfig):
         args = event.raw_args
         application = event.application
 
-        if args.has_token("-h") or args.has_token("--help"):
+        if args.has_option_token("-h") or args.has_option_token("--help"):            
             command = application.get_command("help")
 
             # Enable lenient parsing

--- a/tests/args/test_argv_args.py
+++ b/tests/args/test_argv_args.py
@@ -42,6 +42,33 @@ def test_has_token():
     assert not args.has_token("foo")
 
 
+def test_has_option_token():
+    args = ArgvArgs(
+        [
+            "console",
+            "server",
+            "add",
+            "--port",
+            "80",
+            "localhost",
+            "--",
+            "-h",
+            "--test",
+            "remainder",
+        ]
+    )
+
+    assert args.has_option_token("server")
+    assert args.has_option_token("add")
+    assert args.has_option_token("--port")
+    assert args.has_option_token("80")
+    assert args.has_option_token("localhost")
+    assert not args.has_option_token("console")
+    assert not args.has_option_token("-h")
+    assert not args.has_option_token("--test")
+    assert not args.has_option_token("remainder")
+
+
 def test_to_string():
     args = ArgvArgs(["console", "server", "add", "--port", "80", "localhost"])
 

--- a/tests/handler/help/test_help_option.py
+++ b/tests/handler/help/test_help_option.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from contextlib import contextmanager
+
+import pytest
+
+from clikit.api.args import Args
+from clikit.api.args.format import Argument
+from clikit.args.string_args import StringArgs
+from clikit.config.default_application_config import DefaultApplicationConfig
+from clikit.console_application import ConsoleApplication
+from clikit.io.output_stream import BufferedOutputStream
+
+
+@pytest.fixture()
+def app():
+    config = DefaultApplicationConfig()
+    config.set_catch_exceptions(True)
+    config.set_terminate_after_run(False)
+    config.set_display_name("The Application")
+    config.set_version("1.2.3")
+
+    with config.command("command") as c:
+        with c.sub_command("run") as sc:
+            sc.set_description('Description of "run"')
+            sc.add_argument("args", Argument.MULTI_VALUED, 'Description of "argument"')
+
+    application = ConsoleApplication(config)
+
+    return application
+
+
+def func_spy():
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            decorator.called = True
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    decorator.called = False
+    return decorator
+
+
+@contextmanager
+def help_spy(help_command):
+    spy = func_spy()
+    original = help_command.config.handler.handle
+    try:
+        help_command.config.handler.handle = spy(original)
+        yield spy
+    finally:
+        help_command.config.handler.handle = original
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "command run --help",
+        "command run --help --another",
+        "command run --help -- whatever",
+        "command run -h",
+        "command run -h --another",
+        "command run -h -- whatever",
+    ],
+)
+def test_help_option(app, args):
+    help_command = app.get_command("help")
+    with help_spy(help_command) as spy:
+        app.run(StringArgs(args))
+        assert spy.called, "help command not called"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "command run -- whatever --help",
+        "command run -- whatever -h",
+        "command run -- --help",
+    ],
+)
+def test_help_option_ignored(app, args):
+    help_command = app.get_command("help")
+    with help_spy(help_command) as spy:
+        app.run(StringArgs(args))
+        assert not spy.called, "help command called"


### PR DESCRIPTION
Option parsing is expected to stop after a bare double-dash (`--`).  The current shortcuts for `--help` don't honor this.  When creating wrapper commands that are expected to pass user-provided arguments to an underlying command, this can capture unintended options.

It's desirable to allow passing a `--` to prevent the head command from parsing the remaining arguments.

See sdispater/poetry#1215