### PR TITLE
Add support for ContextManager type pre 3.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pylev = "^1.3"
 
 # The typing module is not in the stdlib in Python 2.7 and 3.4
 typing = { version = "^3.6", python = "~2.7 || ~3.4" }
+typing-extensions = { version = "^3.6", python = ">=3.5.0,<3.5.4" }
 
 # enum34 is needed for Python 2.7
 enum34 = { version = "^1.1", python = "~2.7" }

--- a/src/clikit/api/config/application_config.py
+++ b/src/clikit/api/config/application_config.py
@@ -3,7 +3,11 @@ import re
 from contextlib import contextmanager
 
 from typing import Callable
-from typing import ContextManager
+
+try:
+    from typing import ContextManager
+except ImportError:
+    from typing_extensions import ContextManager
 from typing import List
 from typing import Optional
 


### PR DESCRIPTION
ContextManager was added to typing in 3.5.4, so on 3.5.2 it fails to import. typing-extensions provides a backport.

Fixes https://github.com/sdispater/clikit/issues/7.