### PR TITLE
add support for pastel 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.4"
-pastel = "^0.1.0"
+pastel = "^0.2.0"
 pylev = "^1.3"
 
 # The typing module is not in the stdlib in Python 2.7 and 3.4

--- a/src/clikit/adapter/style_converter.py
+++ b/src/clikit/adapter/style_converter.py
@@ -16,7 +16,7 @@ class StyleConverter(object):
             options.append("bold")
 
         if style.is_underlined():
-            options.append("underscore")
+            options.append("underline")
 
         if style.is_blinking():
             options.append("blink")


### PR DESCRIPTION
Latest  *pastel* version replaces the **underscore** style with **underline**. This in turn breaks native Linux distro packages (e.g. *poetry* in Arch) that rely on current *cleo -> clikit* packages while grabbing the latest *pastel* package.

This change updates *poetry* to 0.2.0 and replaces the **underscore** ref with **underline**.