### PR TITLE
`CliKitException` should inherit from `Exception`

### DIFF
--- a/src/clikit/api/exceptions.py
+++ b/src/clikit/api/exceptions.py
@@ -1,4 +1,4 @@
-class CliKitException(object):
+class CliKitException(Exception):
     """
     Base class for CliKit exceptions
     """


### PR DESCRIPTION
`CliKitException` must inherit from an Exception class to get catched properly.

Fixes: #13  