### PR TITLE
New exception rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ python = "~2.7 || ^3.4"
 pastel = "^0.2.0"
 pylev = "^1.3"
 
+# Woops is only needed for Python ^3.6 to provide
+# better error messsages
+woops = { version = "^0.2.1", python = "^3.6" }
+
 # The typing module is not in the stdlib in Python 2.7 and 3.4
 typing = { version = "^3.6", python = "~2.7 || ~3.4" }
 typing-extensions = { version = "^3.6", python = ">=3.5.0,<3.5.4" }

--- a/src/clikit/adapter/style_converter.py
+++ b/src/clikit/adapter/style_converter.py
@@ -15,6 +15,12 @@ class StyleConverter(object):
         if style.is_bold():
             options.append("bold")
 
+        if style.is_italic():
+            options.append("italic")
+
+        if style.is_dark():
+            options.append("dark")
+
         if style.is_underlined():
             options.append("underline")
 

--- a/src/clikit/api/formatter/style.py
+++ b/src/clikit/api/formatter/style.py
@@ -6,14 +6,14 @@ class Style(object):
     A formatter style.
     """
 
-    _colors = {"black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"}
-
     def __init__(self, tag=None):  # type: (Optional[str]) -> None
         self._tag = tag
         self._fg_color = None
         self._bg_color = None
         self._bold = False
         self._underlined = False
+        self._italic = False
+        self._dark = False
         self._blinking = False
         self._inverse = False
         self._hidden = False
@@ -62,6 +62,22 @@ class Style(object):
 
         return self
 
+    def italic(self, italic=True):  # type: (bool) -> Style
+        """
+        Enables or disables italic
+        """
+        self._italic = italic
+
+        return self
+
+    def dark(self, dark=True):  # type: (bool) -> Style
+        """
+        Enables or disables dark
+        """
+        self._dark = dark
+
+        return self
+
     def blinking(self, blinking=True):  # type: (bool) -> Style
         """
         Enables or disables blinking.
@@ -91,6 +107,12 @@ class Style(object):
 
     def is_underlined(self):  # type: () -> bool
         return self._underlined
+
+    def is_italic(self):  # type: () -> bool
+        return self._italic
+
+    def is_dark(self):  # type: () -> bool
+        return self._dark
 
     def is_blinking(self):  # type: () -> bool
         return self._blinking

--- a/src/clikit/formatter/default_style_set.py
+++ b/src/clikit/formatter/default_style_set.py
@@ -12,7 +12,7 @@ class DefaultStyleSet(StyleSet):
             Style("info").fg("green"),
             Style("comment").fg("cyan"),
             Style("question").fg("blue"),
-            Style("error").fg("red"),
+            Style("error").fg("red").bold(),
             Style("b").bold(),
             Style("u").underlined(),
             Style("c1").fg("cyan"),

--- a/src/clikit/ui/components/exception_trace.py
+++ b/src/clikit/ui/components/exception_trace.py
@@ -2,6 +2,7 @@ import ast
 import inspect
 import io
 import keyword
+import os
 import sys
 import tokenize
 import traceback
@@ -232,7 +233,9 @@ class ExceptionTrace(object):
 
         io.write_line(
             "  at <fg=green>{}</>:<b>{}</b> in <fg=cyan>{}</>".format(
-                current_frame.filename, current_frame.lineno, current_frame.function
+                self._get_relative_file_path(current_frame.filename),
+                current_frame.lineno,
+                current_frame.function,
             )
         )
         for code_line in code_lines:
@@ -266,7 +269,7 @@ class ExceptionTrace(object):
                         "  <fg=yellow>{:>{}}</>  <fg=default;options=bold>{}</>:<b>{}</b> in <fg=cyan>{}</>".format(
                             i + 1,
                             max_frame_length,
-                            frame.filename,
+                            self._get_relative_file_path(frame.filename),
                             frame.lineno,
                             frame.function,
                         )
@@ -294,6 +297,18 @@ class ExceptionTrace(object):
                         )
 
                     i += 1
+
+    def _get_relative_file_path(self, filepath):
+        cwd = os.getcwd()
+
+        if cwd:
+            filepath = filepath.replace(cwd + os.path.sep, "")
+
+        home = os.path.expanduser("~")
+        if home:
+            filepath = filepath.replace(home + os.path.sep, "~" + os.path.sep)
+
+        return filepath
 
     def _render_traceback(self, io, tb):  # type: (IO, ...) -> None
         frames = []

--- a/src/clikit/ui/components/exception_trace.py
+++ b/src/clikit/ui/components/exception_trace.py
@@ -1,11 +1,127 @@
 import ast
 import inspect
+import io
 import keyword
 import sys
+import token
+import tokenize
 import traceback
+
+from woops.inspector import Inspector
 
 from clikit.api.io import IO
 from clikit.utils._compat import PY2
+from clikit.utils._compat import PY36
+from clikit.utils._compat import encode
+
+
+class Highlighter(object):
+
+    TOKEN_DEFAULT = "token_default"
+    TOKEN_COMMENT = "token_comment"
+    TOKEN_STRING = "token_string"
+    TOKEN_KEYWORD = "token_keyword"
+    LINE_MARKER = "line_marker"
+    LINE_NUMBER = "line_number"
+
+    DEFAULT_THEME = {
+        TOKEN_STRING: "fg=red",
+        TOKEN_COMMENT: "fg=yellow",
+        TOKEN_KEYWORD: "fg=green",
+        TOKEN_DEFAULT: "fg=white",
+        LINE_MARKER: "fg=red",
+        LINE_NUMBER: "fg=black;options=bold",
+    }
+
+    def __init__(self):
+        self._theme = self.DEFAULT_THEME.copy()
+
+    def code_snippet(self, source, line, lines_before=2, lines_after=2):
+        token_lines = self.highlighted_lines(source)
+        token_lines = self.line_numbers(token_lines, line)
+
+        offset = line - lines_before - 1
+        offset = max(offset, 0)
+        length = lines_after + lines_before + 1
+        token_lines = token_lines[offset : offset + length]
+
+        return token_lines
+
+    def highlighted_lines(self, source):
+        source = source.replace("\r\n", "\n").replace("\r", "\n")
+
+        return self.split_to_lines(source)
+
+    def split_to_lines(self, source):
+        lines = []
+
+        for i, raw_line in enumerate(source.split("\n")):
+            output = []
+            tokens = tokenize.tokenize(io.BytesIO(encode(raw_line)).readline)
+            current_token = None
+            current_col = 1
+            line = ""
+            buffer = ""
+            current_type = None
+            for token_info in tokens:
+                token_type, token_string, start, end, _ = token_info
+                lineno = start[0]
+                if lineno == 0:
+                    # Encoding line
+                    continue
+
+                if token_type == token.ENDMARKER:
+                    continue
+
+                if start[1] > current_col:
+                    buffer += raw_line[current_col : start[1]]
+
+                if token_string in keyword.kwlist:
+                    new_type = self.TOKEN_KEYWORD
+                elif token_type == token.STRING:
+                    new_type = self.TOKEN_STRING
+                else:
+                    new_type = self.TOKEN_DEFAULT
+
+                if current_type is None:
+                    current_type = new_type
+
+                if current_type != new_type:
+                    line += "<{}>{}</>".format(self._theme[current_type], buffer)
+                    buffer = ""
+                    current_type = new_type
+
+                buffer += token_string
+                current_col = end[1]
+
+            if current_type is not None:
+                line += "<{}>{}</>".format(self._theme[current_type], buffer)
+
+            lines.append(line)
+
+        return lines
+
+    def line_numbers(self, lines, mark_line=None):
+        max_line_length = len(str(len(lines)))
+
+        snippet_lines = []
+        for i, line in enumerate(lines):
+            if mark_line is not None:
+                if mark_line == i + 1:
+                    snippet = "  <{}>></> ".format(self._theme[self.LINE_MARKER])
+                else:
+                    snippet = "    "
+
+            line_number = "{:>{}}".format(i + 1, max_line_length)
+            snippet += "<{}>{}</><{}>|</> {}".format(
+                "b" if mark_line == i + 1 else self._theme[self.LINE_NUMBER],
+                line_number,
+                self._theme[self.LINE_NUMBER],
+                line,
+            )
+            snippet_lines.append(snippet)
+
+        return snippet_lines
 
 
 class ExceptionTrace(object):
@@ -36,6 +152,7 @@ class ExceptionTrace(object):
     def __init__(self, exception):  # type: (Exception) -> None
         self._exception = exception
         self._exc_info = sys.exc_info()
+        self._higlighter = Highlighter()
 
     def render(self, io, simple=False):  # type: (IO, bool) -> None
         if hasattr(self._exception, "__traceback__"):
@@ -43,19 +160,73 @@ class ExceptionTrace(object):
         else:
             tb = self._exc_info[2]
 
-        title = ""
         if not simple:
-            title += "\n[<error>{}</error>]\n".format(
-                self._exception.__class__.__name__
+            title = "\n<error>{}</error>\n\n<b>{}</b>".format(
+                self._exception.__class__.__name__, str(self._exception)
             )
-
-        title += "<error>{}</error>".format(str(self._exception))
+        else:
+            title = "<error>{}</error>".format(str(self._exception))
 
         io.write_line(title)
 
-        if not simple and io.is_verbose():
+        if simple:
+            return
+
+        if PY36:
+            io.write_line("")
+            return self._render_pretty_error(io)
+
+        if io.is_verbose():
             io.write_line("")
             self._render_traceback(io, tb)
+
+    def _render_pretty_error(self, io):
+        inspector = Inspector(self._exception)
+
+        if not inspector.frames:
+            return
+
+        frame = inspector.frames[-1]
+        code_lines = self._higlighter.code_snippet(
+            frame.file_content, frame.lineno, 4, 4
+        )
+
+        io.write_line(
+            "at <c1>{}</c1> line <b>{}</b>".format(frame.filename, frame.lineno)
+        )
+        io.write_line("")
+        for code_line in code_lines:
+            io.write_line(code_line)
+
+        if io.is_verbose():
+
+            max_frame_length = len(str(len(inspector.frames[:-1])))
+            for i, frame in enumerate(reversed(inspector.frames[:-1])):
+                io.write_line("")
+                io.write_line(
+                    "<c1>{:>{}}</c1> in <c2>{}</c2> at <c1>{}</c1> line <b>{}</b>".format(
+                        i + 1,
+                        max_frame_length,
+                        frame.function,
+                        frame.filename,
+                        frame.lineno,
+                    )
+                )
+                if not io.is_debug():
+                    io.write_line(
+                        "{} {}".format(
+                            " " * max_frame_length,
+                            self._higlighter.split_to_lines(frame.line.lstrip())[0],
+                        )
+                    )
+                else:
+                    code_lines = self._higlighter.code_snippet(
+                        frame.file_content, frame.lineno,
+                    )
+
+                    io.write_line("")
+                    for code_line in code_lines:
+                        io.write_line(code_line)
 
     def _render_traceback(self, io, tb):  # type: (IO, ...) -> None
         frames = []

--- a/tests/ui/components/test_exception_trace.py
+++ b/tests/ui/components/test_exception_trace.py
@@ -1,10 +1,19 @@
+import re
+import pytest
+
 from clikit.api.io.flags import VERBOSE
 from clikit.io.buffered_io import BufferedIO
 from clikit.ui.components.exception_trace import ExceptionTrace
-from clikit.utils._compat import PY2, PY38
+from clikit.utils._compat import PY36
+from clikit.utils._compat import PY38
 
 
-def test_render():
+def fail():
+    raise Exception("Failed")
+
+
+@pytest.mark.skipif(PY36, reason="Legacy error messages are Python <3.6 only")
+def test_render_legacy_error_message():
     io = BufferedIO()
 
     try:
@@ -16,13 +25,50 @@ def test_render():
 
     expected = """\
 
-[Exception]
+Exception
+
 Failed
 """
     assert expected == io.fetch_output()
 
 
-def test_render_verbose():
+@pytest.mark.skipif(
+    not PY36, reason="Better error messages are only available for Python ^3.6"
+)
+def test_render_better_error_message():
+    io = BufferedIO()
+
+    try:
+        raise Exception("Failed")
+    except Exception as e:
+        trace = ExceptionTrace(e)
+
+    trace.render(io)
+
+    expected = """\
+
+Exception
+
+Failed
+
+at {}:42 in test_render_better_error_message
+     38| def test_render_better_error_message():
+     39|     io = BufferedIO()
+     40| 
+     41|     try:
+  >  42|         raise Exception("Failed")
+     43|     except Exception as e:
+     44|         trace = ExceptionTrace(e)
+     45| 
+     46|     trace.render(io)
+""".format(
+        __file__
+    )
+    assert expected == io.fetch_output()
+
+
+@pytest.mark.skipif(PY36, reason="Legacy error messages are Python <3.6 only")
+def test_render_verbose_legacy():
     io = BufferedIO()
     io.set_verbosity(VERBOSE)
 
@@ -39,14 +85,118 @@ def test_render_verbose():
 
     expected = """\
 
-[Exception]
+Exception
+
 Failed
 
 Traceback (most recent call last):
-  File "{}", line 30, in test_render_verbose
+  File "{}", line 76, in test_render_verbose_legacy
     raise Exception({})
 
 """.format(
         __file__, msg
     )
     assert expected == io.fetch_output()
+
+
+@pytest.mark.skipif(
+    not PY36, reason="Better error messages are only available for Python ^3.6"
+)
+def test_render_verbose_better_error_message():
+    io = BufferedIO()
+    io.set_verbosity(VERBOSE)
+
+    try:
+        fail()
+    except Exception as e:  # Exception
+        trace = ExceptionTrace(e)
+
+    trace.render(io)
+
+    expected = r"""^
+Exception
+
+Failed
+
+at {}:12 in fail
+      8| from clikit.utils._compat import PY38
+      9| 
+     10| 
+     11| def fail():
+  >  12|     raise Exception("Failed")
+     13| 
+     14| 
+     15| @pytest.mark.skipif(PY36, reason="Legacy error messages are Python <3.6 only")
+     16| def test_render_legacy_error_message():
+
+Stack trace:
+
+ 1 at {}:110 in test_render_verbose_better_error_message
+    108| 
+    109|     try:
+  > 110|         fail()
+    111|     except Exception as e:  # Exception
+    112|         trace = ExceptionTrace(e)
+""".format(
+        re.escape(__file__), re.escape(__file__)
+    )
+
+    assert re.match(expected, io.fetch_output()) is not None
+
+
+def recursion_error():
+    recursion_error()
+
+
+@pytest.mark.skipif(
+    not PY36, reason="Better error messages are only available for Python ^3.6"
+)
+def test_render_verbose_better_error_message_recursion_error():
+    io = BufferedIO()
+    io.set_verbosity(VERBOSE)
+
+    try:
+        recursion_error()
+    except RecursionError as e:
+        trace = ExceptionTrace(e)
+
+    trace.render(io)
+
+    expected = r"""^
+RecursionError
+
+maximum recursion depth exceeded
+
+at {}:148 in recursion_error
+    144\|     assert re.match\(expected, io.fetch_output\(\)\) is not None
+    145\| 
+    146\| 
+    147\| def recursion_error\(\):
+  > 148\|     recursion_error\(\)
+    149\| 
+    150\| 
+    151\| @pytest.mark.skipif\(
+    152\|     not PY36, reason="Better error messages are only available for Python \^3\.6"
+
+Stack trace:
+
+... Previous 1 frame repeated \d+ times
+
+\d+ at {}:148 in recursion_error
+    146\| 
+    147\| def recursion_error\(\):
+  > 148\|     recursion_error\(\)
+    149\| 
+    150\| 
+
+\d+ at {}:159 in test_render_verbose_better_error_message_recursion_error
+    157\| 
+    158\|     try:
+  > 159\|         recursion_error\(\)
+    160\|     except RecursionError as e:
+    161\|         trace = ExceptionTrace\(e\)
+""".format(
+        re.escape(__file__), re.escape(__file__), re.escape(__file__)
+    )
+
+    assert re.match(expected, io.fetch_output()) is not None

--- a/tests/ui/components/test_exception_trace.py
+++ b/tests/ui/components/test_exception_trace.py
@@ -63,7 +63,7 @@ def test_render_better_error_message():
        46| 
        47|     trace.render(io)
 """.format(
-        __file__
+        trace._get_relative_file_path(__file__)
     )
     assert expected == io.fetch_output()
 
@@ -139,7 +139,8 @@ def test_render_debug_better_error_message():
       112\|     except Exception as e:  # Exception
       113\|         trace = ExceptionTrace\(e\)
 """.format(
-        re.escape(__file__), re.escape(__file__)
+        re.escape(trace._get_relative_file_path(__file__)),
+        re.escape(trace._get_relative_file_path(__file__)),
     )
 
     assert re.match(expected, io.fetch_output()) is not None
@@ -168,36 +169,38 @@ def test_render_debug_better_error_message_recursion_error():
 
   maximum recursion depth exceeded
 
-  at {}:149 in recursion_error
-      145\|     assert re.match\(expected, io.fetch_output\(\)\) is not None
-      146\| 
+  at {}:150 in recursion_error
+      146\|     assert re.match\(expected, io.fetch_output\(\)\) is not None
       147\| 
-      148\| def recursion_error\(\):
-    > 149\|     recursion_error\(\)
-      150\| 
+      148\| 
+      149\| def recursion_error\(\):
+    > 150\|     recursion_error\(\)
       151\| 
-      152\| @pytest.mark.skipif\(
-      153\|     not PY36, reason="Better error messages are only available for Python \^3\.6"
+      152\| 
+      153\| @pytest.mark.skipif\(
+      154\|     not PY36, reason="Better error messages are only available for Python \^3\.6"
 
   Stack trace:
 
   ...  Previous 1 frame repeated \d+ times
 
-  \d+  {}:149 in recursion_error
-        147\| 
-        148\| def recursion_error\(\):
-      > 149\|     recursion_error\(\)
-        150\| 
+  \d+  {}:150 in recursion_error
+        148\| 
+        149\| def recursion_error\(\):
+      > 150\|     recursion_error\(\)
         151\| 
+        152\| 
 
-  \d+  {}:160 in test_render_debug_better_error_message_recursion_error
-        158\| 
-        159\|     try:
-      > 160\|         recursion_error\(\)
-        161\|     except RecursionError as e:
-        162\|         trace = ExceptionTrace\(e\)
+  \d+  {}:161 in test_render_debug_better_error_message_recursion_error
+        159\| 
+        160\|     try:
+      > 161\|         recursion_error\(\)
+        162\|     except RecursionError as e:
+        163\|         trace = ExceptionTrace\(e\)
 """.format(
-        re.escape(__file__), re.escape(__file__), re.escape(__file__)
+        re.escape(trace._get_relative_file_path(__file__)),
+        re.escape(trace._get_relative_file_path(__file__)),
+        re.escape(trace._get_relative_file_path(__file__)),
     )
 
     assert re.match(expected, io.fetch_output()) is not None
@@ -235,10 +238,11 @@ def test_render_verbose_better_error_message():
 
   Stack trace:
 
-  1  {}:214 in test_render_verbose_better_error_message
+  1  {}:217 in test_render_verbose_better_error_message
      fail\(\)
 """.format(
-        re.escape(__file__), re.escape(__file__)
+        re.escape(trace._get_relative_file_path(__file__)),
+        re.escape(trace._get_relative_file_path(__file__)),
     )
 
     assert re.match(expected, io.fetch_output()) is not None


### PR DESCRIPTION
This PR adds a new beautiful exception rendering.

The level of detail regarding the exception will depend on the level of verbosity of the executed command. The stack trace will only be displayed if the command is at least verbose and a more detail stack trace will be displayed if the command is in debug mode.

The stack trace will also be collapsed if there are duplicated frames for instance if the exception is caused by a recursion error.

The chosen colors and styles should work equally well for dark and light console themes.

This new rendering is only available for Python 3.6+.

Here are some examples:

**Verbose mode**

<img width="1219" alt="Screenshot 2020-03-25 at 19 49 43" src="https://user-images.githubusercontent.com/555648/77593165-0862f500-6ef4-11ea-8d88-7e0ab04d7bc6.png">

**Debug mode**

<img width="1219" alt="Screenshot 2020-03-25 at 19 51 08" src="https://user-images.githubusercontent.com/555648/77593239-2deffe80-6ef4-11ea-9142-c88aa9b92164.png">

**Collapsed frames**

<img width="660" alt="Screenshot 2020-03-25 at 19 58 08" src="https://user-images.githubusercontent.com/555648/77593248-37796680-6ef4-11ea-9e1a-a0a4d7a8ada2.png">
