### PR TITLE
Exception display improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ python = "~2.7 || ^3.4"
 pastel = "^0.2.0"
 pylev = "^1.3"
 
-# Woops is only needed for Python ^3.6 to provide
+# Crashtest is only needed for Python ^3.6 to provide
 # better error messsages
-woops = { version = "^0.2.1", python = "^3.6" }
+crashtest = { version = "^0.3.0", python = "^3.6" }
 
 # The typing module is not in the stdlib in Python 2.7 and 3.4
 typing = { version = "^3.6", python = "~2.7 || ~3.4" }

--- a/src/clikit/api/config/application_config.py
+++ b/src/clikit/api/config/application_config.py
@@ -15,6 +15,7 @@ from clikit.api.event import EventDispatcher
 from clikit.api.formatter import Style
 from clikit.api.formatter import StyleSet
 from clikit.api.command.exceptions import NoSuchCommandException
+from clikit.utils._compat import PY36
 
 from .command_config import CommandConfig
 from .config import Config
@@ -41,6 +42,15 @@ class ApplicationConfig(Config):
         self._style_set = None
         self._dispatcher = None
         self._pre_resolve_hooks = []  # type: List[Callable]
+
+        if PY36:
+            from crashtest.solution_providers.solution_provider_repository import (
+                SolutionProviderRepository,
+            )
+
+            self._solution_provider_repository = SolutionProviderRepository()
+        else:
+            self._solution_provider_repository = None
 
         super(ApplicationConfig, self).__init__()
 
@@ -257,3 +267,7 @@ class ApplicationConfig(Config):
     @property
     def default_command_resolver(self):
         raise NotImplementedError()
+
+    @property
+    def solution_provider_repository(self):
+        return self._solution_provider_repository

--- a/src/clikit/console_application.py
+++ b/src/clikit/console_application.py
@@ -135,7 +135,10 @@ class ConsoleApplication(BaseApplication):
             if not self._config.is_exception_caught():
                 raise
 
-            trace = ExceptionTrace(e)
+            trace = ExceptionTrace(
+                e,
+                solution_provider_repository=self._config.solution_provider_repository,
+            )
             trace.render(io, simple=isinstance(e, CliKitException))
 
             status_code = self.exception_to_exit_code(e)

--- a/src/clikit/ui/components/exception_trace.py
+++ b/src/clikit/ui/components/exception_trace.py
@@ -99,12 +99,9 @@ class Highlighter(object):
                 current_col = 0
                 buffer = ""
 
-            if start[1] > current_col:
-                buffer += token_info.line[current_col : start[1]]
-
             if token_string in self.KEYWORDS:
                 new_type = self.TOKEN_KEYWORD
-            elif token_string in self.BUILTINS:
+            elif token_string in self.BUILTINS or token_string == "self":
                 new_type = self.TOKEN_BUILTIN
             elif token_type == tokenize.STRING:
                 new_type = self.TOKEN_STRING
@@ -122,14 +119,30 @@ class Highlighter(object):
             if current_type is None:
                 current_type = new_type
 
+            if start[1] > current_col:
+                buffer += token_info.line[current_col : start[1]]
+
             if current_type != new_type:
                 line += "<{}>{}</>".format(self._theme[current_type], buffer)
                 buffer = ""
                 current_type = new_type
 
+            if lineno < end[0]:
+                # The token spans multiple lines
+                lines.append(line)
+                token_lines = token_string.split("\n")
+                for l in token_lines[1:-1]:
+                    lines.append("<{}>{}</>".format(self._theme[current_type], l))
+
+                current_line = end[0]
+                buffer = token_lines[-1][: end[1]]
+                line = ""
+                continue
+
             buffer += token_string
             current_col = end[1]
             current_token_info = token_info
+            current_line = lineno
 
         return lines
 

--- a/src/clikit/ui/components/exception_trace.py
+++ b/src/clikit/ui/components/exception_trace.py
@@ -3,6 +3,7 @@ import inspect
 import io
 import keyword
 import os
+import re
 import sys
 import tokenize
 import traceback
@@ -186,6 +187,12 @@ class ExceptionTrace(object):
         self._exception = exception
         self._exc_info = sys.exc_info()
         self._higlighter = Highlighter()
+        self._ignore = None
+
+    def ignore_files_in(self, ignore):  # type: (str) -> ExceptionTrace
+        self._ignore = ignore
+
+        return self
 
     def render(self, io, simple=False):  # type: (IO, bool) -> None
         if simple:
@@ -273,6 +280,9 @@ class ExceptionTrace(object):
                     i += len(collection) * collection.repetitions
 
                 for frame in reversed(collection):
+                    if self._ignore and re.match(self._ignore, frame.filename):
+                        continue
+
                     self._render_line(
                         io,
                         "<fg=yellow>{:>{}}</>  <fg=default;options=bold>{}</>:<b>{}</b> in <fg=cyan>{}</>".format(

--- a/src/clikit/ui/components/exception_trace.py
+++ b/src/clikit/ui/components/exception_trace.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import ast
 import inspect
 import io
@@ -70,7 +71,6 @@ class Highlighter(object):
         current_type = None
         tokens = tokenize.tokenize(io.BytesIO(encode(source)).readline)
         line = ""
-        current_token_info = None
         for token_info in tokens:
             token_type, token_string, start, end, _ = token_info
             lineno = start[0]
@@ -293,10 +293,10 @@ class ExceptionTrace(object):
 
             self._render_line(
                 io,
-                "<fg=blue;options=bold>• </><fg=default;options=bold>{}</>: {} {}".format(
+                "<fg=blue;options=bold>• </><fg=default;options=bold>{}</>: {}{}".format(
                     title.rstrip("."),
                     description,
-                    ", ".join("\n    <fg=blue>{}</>".format(link) for link in links),
+                    ",".join("\n    <fg=blue>{}</>".format(link) for link in links),
                 ),
                 True,
             )

--- a/tests/ui/components/helpers.py
+++ b/tests/ui/components/helpers.py
@@ -1,0 +1,5 @@
+def outer():
+    def inner():
+        raise Exception("Foo")
+
+    inner()

--- a/tests/ui/components/test_exception_trace.py
+++ b/tests/ui/components/test_exception_trace.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import re
 import pytest
 
@@ -52,16 +53,16 @@ def test_render_better_error_message():
 
   Failed
 
-  at {}:43 in test_render_better_error_message
-       39| def test_render_better_error_message():
-       40|     io = BufferedIO()
-       41| 
-       42|     try:
-    >  43|         raise Exception("Failed")
-       44|     except Exception as e:
-       45|         trace = ExceptionTrace(e)
-       46| 
-       47|     trace.render(io)
+  at {}:44 in test_render_better_error_message
+       40| def test_render_better_error_message():
+       41|     io = BufferedIO()
+       42| 
+       43|     try:
+    >  44|         raise Exception("Failed")
+       45|     except Exception as e:
+       46|         trace = ExceptionTrace(e)
+       47| 
+       48|     trace.render(io)
 """.format(
         trace._get_relative_file_path(__file__)
     )
@@ -91,7 +92,7 @@ Exception
 Failed
 
 Traceback (most recent call last):
-  File "{}", line 77, in test_render_verbose_legacy
+  File "{}", line 78, in test_render_verbose_legacy
     raise Exception({})
 
 """.format(
@@ -115,29 +116,29 @@ def test_render_debug_better_error_message():
     trace.render(io)
 
     expected = r"""^
+  Stack trace:
+
+  1  {}:112 in test_render_debug_better_error_message
+      110\| 
+      111\|     try:
+    > 112\|         fail\(\)
+      113\|     except Exception as e:  # Exception
+      114\|         trace = ExceptionTrace\(e\)
+
   Exception
 
   Failed
 
-  at {}:13 in fail
-        9\| from clikit.utils._compat import PY38
-       10\| 
+  at {}:14 in fail
+       10\| from clikit.utils._compat import PY38
        11\| 
-       12\| def fail\(\):
-    >  13\|     raise Exception\("Failed"\)
-       14\| 
+       12\| 
+       13\| def fail\(\):
+    >  14\|     raise Exception\("Failed"\)
        15\| 
-       16\| @pytest.mark.skipif\(PY36, reason="Legacy error messages are Python <3.6 only"\)
-       17\| def test_render_legacy_error_message\(\):
-
-  Stack trace:
-
-  1  {}:111 in test_render_debug_better_error_message
-      109\| 
-      110\|     try:
-    > 111\|         fail\(\)
-      112\|     except Exception as e:  # Exception
-      113\|         trace = ExceptionTrace\(e\)
+       16\| 
+       17\| @pytest.mark.skipif\(PY36, reason="Legacy error messages are Python <3.6 only"\)
+       18\| def test_render_legacy_error_message\(\):
 """.format(
         re.escape(trace._get_relative_file_path(__file__)),
         re.escape(trace._get_relative_file_path(__file__)),
@@ -165,38 +166,38 @@ def test_render_debug_better_error_message_recursion_error():
     trace.render(io)
 
     expected = r"""^
+  Stack trace:
+
+  \d+  {}:162 in test_render_debug_better_error_message_recursion_error
+        160\| 
+        161\|     try:
+      > 162\|         recursion_error\(\)
+        163\|     except RecursionError as e:
+        164\|         trace = ExceptionTrace\(e\)
+
+  ...  Previous frame repeated \d+ times
+
+  \s*\d+  {}:151 in recursion_error
+        149\| 
+        150\| def recursion_error\(\):
+      > 151\|     recursion_error\(\)
+        152\| 
+        153\| 
+
   RecursionError
 
   maximum recursion depth exceeded
 
-  at {}:150 in recursion_error
-      146\|     assert re.match\(expected, io.fetch_output\(\)\) is not None
-      147\| 
+  at {}:151 in recursion_error
+      147\|     assert re.match\(expected, io.fetch_output\(\)\) is not None
       148\| 
-      149\| def recursion_error\(\):
-    > 150\|     recursion_error\(\)
-      151\| 
+      149\| 
+      150\| def recursion_error\(\):
+    > 151\|     recursion_error\(\)
       152\| 
-      153\| @pytest.mark.skipif\(
-      154\|     not PY36, reason="Better error messages are only available for Python \^3\.6"
-
-  Stack trace:
-
-  ...  Previous frame repeated \d+ times
-
-  \d+  {}:150 in recursion_error
-        148\| 
-        149\| def recursion_error\(\):
-      > 150\|     recursion_error\(\)
-        151\| 
-        152\| 
-
-  \d+  {}:161 in test_render_debug_better_error_message_recursion_error
-        159\| 
-        160\|     try:
-      > 161\|         recursion_error\(\)
-        162\|     except RecursionError as e:
-        163\|         trace = ExceptionTrace\(e\)
+      153\| 
+      154\| @pytest.mark.skipif\(
+      155\|     not PY36, reason="Better error messages are only available for Python \^3\.6"
 """.format(
         re.escape(trace._get_relative_file_path(__file__)),
         re.escape(trace._get_relative_file_path(__file__)),
@@ -221,25 +222,25 @@ def test_render_verbose_better_error_message():
     trace.render(io)
 
     expected = r"""^
+  Stack trace:
+
+  1  {}:218 in test_render_verbose_better_error_message
+     fail\(\)
+
   Exception
 
   Failed
 
-  at {}:13 in fail
-        9\| from clikit.utils._compat import PY38
-       10\| 
+  at {}:14 in fail
+       10\| from clikit.utils._compat import PY38
        11\| 
-       12\| def fail\(\):
-    >  13\|     raise Exception\("Failed"\)
-       14\| 
+       12\| 
+       13\| def fail\(\):
+    >  14\|     raise Exception\("Failed"\)
        15\| 
-       16\| @pytest.mark.skipif\(PY36, reason="Legacy error messages are Python <3.6 only"\)
-       17\| def test_render_legacy_error_message\(\):
-
-  Stack trace:
-
-  1  {}:217 in test_render_verbose_better_error_message
-     fail\(\)
+       16\| 
+       17\| @pytest.mark.skipif\(PY36, reason="Legacy error messages are Python <3.6 only"\)
+       18\| def test_render_legacy_error_message\(\):
 """.format(
         re.escape(trace._get_relative_file_path(__file__)),
         re.escape(trace._get_relative_file_path(__file__)),
@@ -274,3 +275,193 @@ def test_render_debug_better_error_message_recursion_error_with_multiple_duplica
     )
 
     assert re.search(expected, io.fetch_output()) is not None
+
+
+@pytest.mark.skipif(
+    not PY36, reason="Better error messages are only available for Python ^3.6"
+)
+def test_render_can_ignore_given_files():
+    import os
+    from .helpers import outer
+
+    io = BufferedIO()
+    io.set_verbosity(VERBOSE)
+
+    def call():
+        def run():
+            outer()
+
+        run()
+
+    with pytest.raises(Exception) as e:
+        call()
+
+    trace = ExceptionTrace(e.value)
+    helpers_file = os.path.join(os.path.dirname(__file__), "helpers.py")
+    trace.ignore_files_in("^{}$".format(re.escape(helpers_file)))
+
+    trace.render(io)
+
+    expected = """
+  Stack trace:
+
+  2  {}:297 in test_render_can_ignore_given_files
+     call()
+
+  1  {}:294 in call
+     run()
+
+  Exception
+
+  Foo
+
+  at {}:3 in inner
+      1| def outer():
+      2|     def inner():
+    > 3|         raise Exception("Foo")
+      4| 
+      5|     inner()
+      6| 
+""".format(
+        trace._get_relative_file_path(__file__),
+        trace._get_relative_file_path(__file__),
+        trace._get_relative_file_path(helpers_file),
+    )
+
+    assert expected == io.fetch_output()
+
+
+@pytest.mark.skipif(
+    not PY36, reason="Better error messages are only available for Python ^3.6"
+)
+def test_render_shows_ignored_files_if_in_debug_mode():
+    import os
+    from .helpers import outer
+
+    io = BufferedIO()
+    io.set_verbosity(DEBUG)
+
+    def call():
+        def run():
+            outer()
+
+        run()
+
+    with pytest.raises(Exception) as e:
+        call()
+
+    trace = ExceptionTrace(e.value)
+    helpers_file = os.path.join(os.path.dirname(__file__), "helpers.py")
+    trace.ignore_files_in("^{}$".format(re.escape(helpers_file)))
+
+    trace.render(io)
+
+    expected = """
+  Stack trace:
+
+  4  {}:351 in test_render_shows_ignored_files_if_in_debug_mode
+      349| 
+      350|     with pytest.raises(Exception) as e:
+    > 351|         call()
+      352| 
+      353|     trace = ExceptionTrace(e.value)
+
+  3  {}:348 in call
+      346|             outer()
+      347| 
+    > 348|         run()
+      349| 
+      350|     with pytest.raises(Exception) as e:
+
+  2  {}:346 in run
+      344|     def call():
+      345|         def run():
+    > 346|             outer()
+      347| 
+      348|         run()
+
+  1  {}:5 in outer
+      3|         raise Exception("Foo")
+      4| 
+    > 5|     inner()
+      6| 
+
+  Exception
+
+  Foo
+
+  at {}:3 in inner
+      1| def outer():
+      2|     def inner():
+    > 3|         raise Exception("Foo")
+      4| 
+      5|     inner()
+      6| 
+""".format(
+        trace._get_relative_file_path(__file__),
+        trace._get_relative_file_path(__file__),
+        trace._get_relative_file_path(__file__),
+        trace._get_relative_file_path(helpers_file),
+        trace._get_relative_file_path(helpers_file),
+    )
+
+    assert expected == io.fetch_output()
+
+
+@pytest.mark.skipif(
+    not PY36, reason="Better error messages are only available for Python ^3.6"
+)
+def test_render_supports_solutions():
+    from crashtest.contracts.provides_solution import ProvidesSolution
+    from crashtest.contracts.base_solution import BaseSolution
+    from crashtest.solution_providers.solution_provider_repository import (
+        SolutionProviderRepository,
+    )
+
+    class CustomError(ProvidesSolution, Exception):
+        @property
+        def solution(self):
+            solution = BaseSolution("Solution Title.", "Solution Description")
+            solution.documentation_links.append("https://example.com")
+            solution.documentation_links.append("https://example2.com")
+
+            return solution
+
+    io = BufferedIO()
+
+    def call():
+        raise CustomError("Error with solution")
+
+    with pytest.raises(CustomError) as e:
+        call()
+
+    trace = ExceptionTrace(
+        e.value, solution_provider_repository=SolutionProviderRepository()
+    )
+
+    trace.render(io)
+
+    expected = """
+  CustomError
+
+  Error with solution
+
+  at {}:433 in call
+      429| 
+      430|     io = BufferedIO()
+      431| 
+      432|     def call():
+    > 433|         raise CustomError("Error with solution")
+      434| 
+      435|     with pytest.raises(CustomError) as e:
+      436|         call()
+      437| 
+
+  • Solution Title: Solution Description
+    https://example.com,
+    https://example2.com
+""".format(
+        trace._get_relative_file_path(__file__),
+    )
+
+    assert expected == io.fetch_output()


### PR DESCRIPTION
This PR further improves the handling and display of exceptions:

* The stack trace will be displayed above the actual error, so that the error is visible immediately and to read the trace in a more natural flow.
* Support for error solutions.
* Ability to ignore files in the stack trace by using patterns.
* Fix for the coloring of tokens that spans multiple lines.

**Example**:

<img width="1167" alt="Screenshot 2020-04-17 at 18 02 49" src="https://user-images.githubusercontent.com/555648/79590082-c6823480-80d6-11ea-890a-ab96466aea8a.png">
