### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [0.6.0] - 2020-04-17
+
+### Added
+
+- Support for error solutions ([#24](https://github.com/sdispater/clikit/pull/24)).
+- Ability to ignore files in the stack trace ([#24](https://github.com/sdispater/clikit/pull/24)).
+
+### Changed
+
+- The stack trace will now be displayed above the actual error, so that the error is visible immediately and the read flow of the stack trace is more natural ([#24](https://github.com/sdispater/clikit/pull/24)).
+
+### Fixed
+
+- Fixed the coloring of the code snippets of the stack trace for tokens that span multiple lines ([#24](https://github.com/sdispater/clikit/pull/24)).
+
+
 ## [0.5.1] - 2020-03-27
 
 ### Fixed
@@ -122,7 +138,8 @@
 - Fixed the progress indicator component.
 
 
-[Unreleased]: https://github.com/sdispater/tomlkit/compare/0.5.1...master
+[Unreleased]: https://github.com/sdispater/tomlkit/compare/0.6.0...master
+[0.6.0]: https://github.com/sdispater/tomlkit/releases/tag/0.6.0
 [0.5.1]: https://github.com/sdispater/tomlkit/releases/tag/0.5.1
 [0.5.0]: https://github.com/sdispater/tomlkit/releases/tag/0.5.0
 [0.4.3]: https://github.com/sdispater/tomlkit/releases/tag/0.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "clikit"
-version = "0.5.1"
+version = "0.6.0"
 description = "CliKit is a group of utilities to build beautiful and testable command line interfaces."
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"

--- a/src/clikit/__init__.py
+++ b/src/clikit/__init__.py
@@ -2,4 +2,4 @@ from .api.config.application_config import ApplicationConfig
 from .config.default_application_config import DefaultApplicationConfig
 from .console_application import ConsoleApplication
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"


### PR DESCRIPTION
### Added

- Support for error solutions ([#24](https://github.com/sdispater/clikit/pull/24)).
- Ability to ignore files in the stack trace ([#24](https://github.com/sdispater/clikit/pull/24)).

### Changed

- The stack trace will now be displayed above the actual error, so that the error is visible immediately and the read flow of the stack trace is more natural ([#24](https://github.com/sdispater/clikit/pull/24)).

### Fixed

- Fixed the coloring of the code snippets of the stack trace for tokens that span multiple lines ([#24](https://github.com/sdispater/clikit/pull/24)).
