### PR TITLE
Improve progress bars and indicators

### DIFF
--- a/src/clikit/api/io/io.py
+++ b/src/clikit/api/io/io.py
@@ -202,6 +202,9 @@ class IO(Formatter):
         self._output.set_formatter(formatter)
         self._error_output.set_formatter(formatter)
 
+    def supports_ansi(self):  # type: () -> bool
+        return self._output.supports_ansi()
+
     @property
     def formatter(self):  # type: () -> Formatter
         """
@@ -222,4 +225,6 @@ class IO(Formatter):
         return self._output.formatter.remove_format(string)
 
     def section(self):
-        return IO(self._input, self._output.section(), self._error_output.section())
+        return self.__class__(
+            self._input, self._output.section(), self._error_output.section()
+        )

--- a/src/clikit/io/buffered_io.py
+++ b/src/clikit/io/buffered_io.py
@@ -48,3 +48,11 @@ class BufferedIO(IO):
 
     def clear_error(self):  # type: () -> None
         self.error_output.stream.clear()
+
+    def section(self):
+        io = self.__class__()
+        io._input = self._input
+        io._output = self._output.section()
+        io._error_output = self._error_output.section()
+
+        return io


### PR DESCRIPTION
This PR improves progress bars and indicators in the following ways:

- Progress bars will now update at most every 100 ms by default. This is configurable via the `min_seconds_between_redraws()` method.
- Progress bars and indicators now accept an `Output` instance as well as an `IO` instance. If an `IO` instance is passed the error output will be used.