### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [0.6.1] - 2020-05-31
+
+### Changed
+
+- Progress bars will now update at most every 100ms by default. This is configurable via the `min_seconds_between_redraws()` method ([#29](https://github.com/sdispater/clikit/pull/29)).
+- Progress bars and indicators now accept an `Output` instance as well as an `IO` instance. If an `IO` instance is passed the error output will be used ([#29](https://github.com/sdispater/clikit/pull/29)).
+- Slightly changed the exception trace rendering ([#30](https://github.com/sdispater/clikit/pull/30)).
+
+### Fixed
+
+- Fixed an error where choices questions accepted negative choices ([#27](https://github.com/sdispater/clikit/pull/27)).
+
+
 ## [0.6.0] - 2020-04-17
 
 ### Added
@@ -138,7 +151,8 @@
 - Fixed the progress indicator component.
 
 
-[Unreleased]: https://github.com/sdispater/tomlkit/compare/0.6.0...master
+[Unreleased]: https://github.com/sdispater/tomlkit/compare/0.6.1...master
+[0.6.1]: https://github.com/sdispater/tomlkit/releases/tag/0.6.1
 [0.6.0]: https://github.com/sdispater/tomlkit/releases/tag/0.6.0
 [0.5.1]: https://github.com/sdispater/tomlkit/releases/tag/0.5.1
 [0.5.0]: https://github.com/sdispater/tomlkit/releases/tag/0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "clikit"
-version = "0.6.0"
+version = "0.6.1"
 description = "CliKit is a group of utilities to build beautiful and testable command line interfaces."
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"

--- a/src/clikit/__init__.py
+++ b/src/clikit/__init__.py
@@ -2,4 +2,4 @@ from .api.config.application_config import ApplicationConfig
 from .config.default_application_config import DefaultApplicationConfig
 from .console_application import ConsoleApplication
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
### Changed

- Progress bars will now update at most every 100ms by default. This is configurable via the `min_seconds_between_redraws()` method ([#29](https://github.com/sdispater/clikit/pull/29)).
- Progress bars and indicators now accept an `Output` instance as well as an `IO` instance. If an `IO` instance is passed the error output will be used ([#29](https://github.com/sdispater/clikit/pull/29)).
- Slightly changed the exception trace rendering ([#30](https://github.com/sdispater/clikit/pull/30)).

### Fixed

- Fixed an error where choices questions accepted negative choices ([#27](https://github.com/sdispater/clikit/pull/27)).
