### PR TITLE
Release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.6.2] - 2020-06-09
+
+### Fixed
+
+- Fixed an error in the package's metadata causing errors on Python 3.5.
+
+
 ## [0.6.1] - 2020-05-31
 
 ### Changed
@@ -151,7 +158,8 @@
 - Fixed the progress indicator component.
 
 
-[Unreleased]: https://github.com/sdispater/tomlkit/compare/0.6.1...master
+[Unreleased]: https://github.com/sdispater/tomlkit/compare/0.6.2...master
+[0.6.2]: https://github.com/sdispater/tomlkit/releases/tag/0.6.2
 [0.6.1]: https://github.com/sdispater/tomlkit/releases/tag/0.6.1
 [0.6.0]: https://github.com/sdispater/tomlkit/releases/tag/0.6.0
 [0.5.1]: https://github.com/sdispater/tomlkit/releases/tag/0.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "clikit"
-version = "0.6.1"
+version = "0.6.2"
 description = "CliKit is a group of utilities to build beautiful and testable command line interfaces."
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"
@@ -26,7 +26,7 @@ crashtest = { version = "^0.3.0", python = "^3.6" }
 
 # The typing module is not in the stdlib in Python 2.7 and 3.4
 typing = { version = "^3.6", python = "~2.7 || ~3.4" }
-typing-extensions = { version = "^3.6", python = ">=3.5.0,<3.5.4" }
+typing-extensions = { version = "^3.6", markers = 'python_version >= "3.5" and python_full_version < "3.5.4"' }
 
 # enum34 is needed for Python 2.7
 enum34 = { version = "^1.1", python = "~2.7" }

--- a/src/clikit/__init__.py
+++ b/src/clikit/__init__.py
@@ -2,4 +2,4 @@ from .api.config.application_config import ApplicationConfig
 from .config.default_application_config import DefaultApplicationConfig
 from .console_application import ConsoleApplication
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"


### PR DESCRIPTION
### Fixed

- Fixed an error in the package's metadata causing errors on Python 3.5.