### PR TITLE
Allow `cwd` to be missing

### DIFF
--- a/src/clikit/ui/components/exception_trace.py
+++ b/src/clikit/ui/components/exception_trace.py
@@ -425,7 +425,10 @@ class ExceptionTrace(object):
         io.write_line("{}{}".format(indent * " ", line))
 
     def _get_relative_file_path(self, filepath):
-        cwd = os.getcwd()
+        try:
+            cwd = os.getcwd()
+        except OSError:
+            cwd = None
 
         if cwd:
             filepath = filepath.replace(cwd + os.path.sep, "")


### PR DESCRIPTION
Handle missing `cwd` to close #42 
On my system the error is FileNotFoundError, but guess it's parent is better choice, for who knows what other causes there may be for broken `cwd`.
Since this code is ran during error handling, I figure it's better to be defensive.