### PR TITLE
Allow crashtest ^0.4.0 in addition to ^0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "clikit"
-version = "0.6.2"
+version = "0.6.3"
 description = "CliKit is a group of utilities to build beautiful and testable command line interfaces."
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"
@@ -22,7 +22,7 @@ pylev = "^1.3"
 
 # Crashtest is only needed for Python ^3.6 to provide
 # better error messsages
-crashtest = { version = "^0.3.0", python = "^3.6" }
+crashtest = { version = ">=0.3.0", python = "^3.6" }
 
 # The typing module is not in the stdlib in Python 2.7 and 3.4
 typing = { version = "^3.6", python = "~2.7 || ~3.4" }


### PR DESCRIPTION
https://github.com/sdispater/clikit/issues/47

https://github.com/sdispater/crashtest/releases 0.4.1 has been released and required by many packages already.